### PR TITLE
Corrected README.md

### DIFF
--- a/plinio/methods/pit/README.md
+++ b/plinio/methods/pit/README.md
@@ -67,7 +67,7 @@ class Net(nn.Module):
         self.lin2 = nn.Linear()
 
 net = Net()
-exclude_types = (nn.Conv1d)
+exclude_types = (nn.Conv1d,)
 pit_net = PIT(net, exclude_types=exclude_types)
 ```
 


### PR DESCRIPTION
At exclude_types, python will infer directly the element within the tuple/set if there is only one element, can be bypassed with ','